### PR TITLE
replace myslq to mysql

### DIFF
--- a/docs/configuration/apiserver.md
+++ b/docs/configuration/apiserver.md
@@ -19,7 +19,7 @@
 
 ```yaml
 database:
-  type: "${APISERVER_DB_TYPE:sqlite}"               # 数据库类型（sqlite,postgres, myslq）
+  type: "${APISERVER_DB_TYPE:sqlite}"               # 数据库类型（sqlite,postgres, mysql）
   host: "${APISERVER_DB_HOST:localhost}"            # 数据库主机地址
   port: ${APISERVER_DB_PORT:5432}                   # 数据库端口
   user: "${APISERVER_DB_USER:postgres}"             # 数据库用户名
@@ -47,7 +47,7 @@ storage:
   
   # 数据库配置（当 type 为 'db' 时使用）
   database:
-    type: "${GATEWAY_DB_TYPE:sqlite}"                   # 数据库类型（sqlite,postgres, myslq）
+    type: "${GATEWAY_DB_TYPE:sqlite}"                   # 数据库类型（sqlite,postgres, mysql）
     host: "${GATEWAY_DB_HOST:localhost}"                # 数据库主机地址
     port: ${GATEWAY_DB_PORT:5432}                       # 数据库端口
     user: "${GATEWAY_DB_USER:postgres}"                 # 数据库用户名

--- a/docs/configuration/mcp-gateway.md
+++ b/docs/configuration/mcp-gateway.md
@@ -28,7 +28,7 @@ storage:
   
   # 数据库配置（当 type 为 'db' 时使用）
   database:
-    type: "${GATEWAY_DB_TYPE:sqlite}"                   # 数据库类型（sqlite,postgres, myslq）
+    type: "${GATEWAY_DB_TYPE:sqlite}"                   # 数据库类型（sqlite,postgres, mysql）
     host: "${GATEWAY_DB_HOST:localhost}"                # 数据库主机地址
     port: ${GATEWAY_DB_PORT:5432}                       # 数据库端口
     user: "${GATEWAY_DB_USER:postgres}"                 # 数据库用户名

--- a/i18n/es/docusaurus-plugin-content-docs/current/configuration/mcp-gateway.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/configuration/mcp-gateway.md
@@ -28,7 +28,7 @@ storage:
   
   # Configuración de base de datos (usado cuando type es 'db')
   database:
-    type: "${GATEWAY_DB_TYPE:sqlite}"                   # Tipo de base de datos (sqlite,postgres, myslq)
+    type: "${GATEWAY_DB_TYPE:sqlite}"                   # Tipo de base de datos (sqlite,postgres, mysql)
     host: "${GATEWAY_DB_HOST:localhost}"                # Dirección del host de la base de datos
     port: ${GATEWAY_DB_PORT:5432}                       # Puerto de la base de datos
     user: "${GATEWAY_DB_USER:postgres}"                 # Usuario de la base de datos

--- a/i18n/hi/docusaurus-plugin-content-docs/current/configuration/mcp-gateway.md
+++ b/i18n/hi/docusaurus-plugin-content-docs/current/configuration/mcp-gateway.md
@@ -28,7 +28,7 @@ storage:
   
   # डेटाबेस कॉन्फ़िगरेशन (जब type 'db' हो)
   database:
-    type: "${GATEWAY_DB_TYPE:sqlite}"                   # डेटाबेस प्रकार (sqlite,postgres, myslq)
+    type: "${GATEWAY_DB_TYPE:sqlite}"                   # डेटाबेस प्रकार (sqlite,postgres, mysql)
     host: "${GATEWAY_DB_HOST:localhost}"                # डेटाबेस होस्ट पता
     port: ${GATEWAY_DB_PORT:5432}                       # डेटाबेस पोर्ट
     user: "${GATEWAY_DB_USER:postgres}"                 # डेटाबेस उपयोगकर्ता नाम


### PR DESCRIPTION
## Summary by Sourcery

Correct the spelling of the MySQL database type in configuration documentation across multiple files and locales.

Documentation:
- Replace typo "myslq" with "mysql" in apiserver and gateway configuration docs
- Update corresponding translations in Spanish and Hindi documentation to reflect the correct database type